### PR TITLE
support `--incompatible_disallow_empty_glob`

### DIFF
--- a/cpan/install.bzl
+++ b/cpan/install.bzl
@@ -5,7 +5,7 @@ load("@rules_perl//perl:perl.bzl", "perl_library")
 
 perl_library(
     name = "{distribution}",
-    srcs = glob(["lib/**/*"]),
+    srcs = glob(["**/*"], exclude=["t/**/*", "xt/**/*"]),
     visibility = ["//visibility:public"],
 )
 """


### PR DESCRIPTION
Fixes empty glob issues for module like [common-sense](https://metacpan.org/dist/common-sense/source) that don't use the `lib` directory
